### PR TITLE
Delete qcacld-3.0 from cm-14.1 branch

### DIFF
--- a/drivers/staging/Kconfig
+++ b/drivers/staging/Kconfig
@@ -110,6 +110,4 @@ source "drivers/staging/wilc1000/Kconfig"
 
 source "drivers/staging/most/Kconfig"
 
-source "drivers/staging/qcacld-3.0/Kconfig"
-
 endif # STAGING


### PR DESCRIPTION
cm-14.1 branch for mata has no qcacld-3.0 folder and causes build to fail